### PR TITLE
update flux controller images to match Big Bang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1]
+
+### Changed
+
+- Updated Flux controller versions to match Big Bang:
+  - helm-controller: v1.4.5 → v1.5.4
+  - kustomize-controller: v1.7.3 → v1.8.4
+  - notification-controller: v1.7.5 → v1.8.4
+  - source-controller: v1.7.4 → v1.8.3
+
 ## [0.3.0]
 
 ### Changed

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,7 +56,7 @@ flux:
 
   helmController:
     image: registry1.dso.mil/ironbank/fluxcd/helm-controller
-    tag: v1.4.5
+    tag: v1.5.4
     resources:
       limits:
         cpu: 1800m
@@ -83,7 +83,7 @@ flux:
 
   kustomizeController:
     image: registry1.dso.mil/ironbank/fluxcd/kustomize-controller
-    tag: v1.7.3
+    tag: v1.8.4
     resources:
       limits:
         cpu: 600m
@@ -110,7 +110,7 @@ flux:
 
   notificationController:
     image: registry1.dso.mil/ironbank/fluxcd/notification-controller
-    tag: v1.7.5
+    tag: v1.8.4
     resources:
       limits:
         cpu: 200m
@@ -137,7 +137,7 @@ flux:
 
   sourceController:
     image: registry1.dso.mil/ironbank/fluxcd/source-controller
-    tag: v1.7.4
+    tag: v1.8.3
     resources:
       limits:
         cpu: 600m


### PR DESCRIPTION
- helm-controller: v1.4.5 → v1.5.4
- kustomize-controller: v1.7.3 → v1.8.4
- notification-controller: v1.7.5 → v1.8.4
- source-controller: v1.7.4 → v1.8.3